### PR TITLE
publish rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 迭代记录
 
+### 1.1.2-rc.2
+
+- 调整 `atc config --force` 命令的行为，不会删掉 config 文件夹，只会清除所有 js 文件
+
 ### 1.1.1-rc.1
 
 - 调整 `atc config --force` 命令的行为，变得更加强硬，现在会强行撸掉 output 重新生成

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astroboy.ts",
-  "version": "1.1.2",
+  "version": "1.1.2-rc.2",
   "description": "基于[astroboy]的DI版本，TypeScript3.2信仰加成",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/builders/config-compiler.ts
+++ b/src/builders/config-compiler.ts
@@ -12,15 +12,19 @@ export function compileFn(options: Partial<ConfigCompilerOptions>) {
     const configFolder = path.resolve(cwd, configRoot || "app/config");
     const outputFolder = path.resolve(cwd, outRoot || "config");
     const files = fs.readdirSync(configFolder);
-    if (!!force) {
+    if (!!force && fs.existsSync(outputFolder)) {
       if (configFolder === outputFolder) {
         throw new Error(
           "Config-Compiler Error: same config-root and output-root is invalid when [force] option is opened."
         );
       }
       // 硬核开关，强撸config文件夹
-      rimraf.sync(outputFolder);
-      fs.mkdirSync(outputFolder);
+      const exists = fs.readdirSync(outputFolder);
+      exists
+        .filter(p => p.endsWith(".js"))
+        .forEach(p => {
+          fs.unlinkSync(`${outputFolder}/${p}`);
+        });
     } else if (!fs.existsSync(outputFolder)) {
       fs.mkdirSync(outputFolder);
     }


### PR DESCRIPTION
### 1.1.2-rc.2

- 调整 `atc config --force` 命令的行为，不会删掉 config 文件夹，只会清除所有 js 文件
